### PR TITLE
Fixing parsing special characters

### DIFF
--- a/lib/whmcs/base.rb
+++ b/lib/whmcs/base.rb
@@ -50,7 +50,7 @@ module WHMCS
         Crack::XML.parse(raw)
       else
         # in case of password encrypt/decrypt - '=' should be properly parsed
-        CGI::unescapeHTML(raw).split(';').map do |line|
+        CGI::unescapeHTML(raw).encode("UTF-8").split(';').map do |line|
           m = /^(\w+)\=(.*)$/.match(line)
           result[ m[1] ] = m[2]
         end

--- a/lib/whmcs/base.rb
+++ b/lib/whmcs/base.rb
@@ -50,7 +50,7 @@ module WHMCS
         Crack::XML.parse(raw)
       else
         # in case of password encrypt/decrypt - '=' should be properly parsed
-        CGI::unescapeHTML(raw).encode("UTF-8").split(';').map do |line|
+        CGI::unescapeHTML(raw).force_encoding("UTF-8").split(';').map do |line|
           m = /^(\w+)\=(.*)$/.match(line)
           result[ m[1] ] = m[2]
         end


### PR DESCRIPTION
When the clients has special characters in client info then the API raise exception.
Force encoding to utf-8 resolve this problem and works in production.